### PR TITLE
fix: clean up properly after touch handler to prevent crashes

### DIFF
--- a/tester/harmony/gesture_handler/src/main/cpp/componentInstances/RNGestureHandlerRootViewComponentInstance.h
+++ b/tester/harmony/gesture_handler/src/main/cpp/componentInstances/RNGestureHandlerRootViewComponentInstance.h
@@ -63,6 +63,7 @@ namespace rnoh {
 
     ~RNGestureHandlerRootViewComponentInstance() override {
       NativeNodeApi::getInstance()->unregisterNodeEvent(m_stackNode.getArkUINodeHandle(), NODE_TOUCH_EVENT);
+      ArkUINodeRegistry::getInstance().unregisterTouchHandler(&m_stackNode);
     }
 
     StackNode &getLocalRootArkUINode() override { return m_stackNode; };

--- a/tester/package.json
+++ b/tester/package.json
@@ -16,7 +16,7 @@
     "react-native": "0.72.5",
     "react-native-gesture-handler": "2.14.1",
     "react-native-harmony": "npm:@rnoh/react-native-harmony@^0.72.26",
-    "react-native-harmony-gesture-handler": "file:../react-native-harmony-gesture-handler/rnoh-react-native-harmony-gesture-handler-2.14.2.tgz"
+    "react-native-harmony-gesture-handler": "file:../react-native-harmony-gesture-handler/rnoh-react-native-harmony-gesture-handler-2.14.3.tgz"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
Related https://gl.swmansion.com/rnoh/react-native-harmony-gesture-handler/-/issues/67

See merge request rnoh/react-native-harmony-gesture-handler!41

(cherry picked from commit d1e86900aaa5d87969c72bb018bc0d332bc79742)