### PR TITLE
fix: fixed handling onTouch events prioritizes handling touch events for child components

### DIFF
--- a/tester/harmony/gesture_handler/src/main/ets/rnoh/RNGHRootTouchHandlerArkTS.ts
+++ b/tester/harmony/gesture_handler/src/main/ets/rnoh/RNGHRootTouchHandlerArkTS.ts
@@ -84,10 +84,13 @@ export class RNGHRootTouchHandlerArkTS {
       }
 
       // send touch to gesture handlers
-      for (const viewTag of this.activeViewTags) {
-        const adapter = this.adapterByViewTag.get(viewTag);
-        if (adapter) {
-          adapter.handleTouch(e);
+      if (this.activeViewTags.size > 0) {
+        let tags = Array.from<number>(this.activeViewTags);
+        for (let i = 0; i < tags.length; i++) {
+          const adapter = this.adapterByViewTag.get(tags[tags.length - 1 - i]);
+          if (adapter) {
+            adapter.handleTouch(e);
+          }
         }
       }
     }


### PR DESCRIPTION
# Summary

- fix: fixed handling onTouch events prioritizes handling touch events for child components
- Close: #18 

## Test Plan
Demo复现：各自gesture响应
```
<GestureHandlerRootView>
      <GestureDetector gesture={outer}>
        <View style={[{width: 180, height: 180, backgroundColor: 'blue'}]}>
          <GestureDetector gesture={inner}>
            <View style={[{width: 80, height: 80, backgroundColor: 'pink'}]} />
          </GestureDetector>
        </View>
      </GestureDetector>
    </GestureHandlerRootView>
```

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

## Version Info
- react-native-harmony: 0.72.28-CAPI
- DevEco Studio: 5.0.3.300
- OH SDK: HarmonyOS NEXT Developer Canary3 SP2
- ROM: 3.0.0.22(Canary3)