### PR TITLE
fix:fixed Gesture.Tap gesture return data property value (#23)

### DIFF
--- a/tester/harmony/gesture_handler/src/main/ets/gesture-handlers/TapGestureHandler.ts
+++ b/tester/harmony/gesture_handler/src/main/ets/gesture-handlers/TapGestureHandler.ts
@@ -51,9 +51,18 @@ export class TapGestureHandler extends GestureHandler {
     this.lastX = this.tracker.getLastAvgX();
     this.lastY = this.tracker.getLastAvgY();
 
-    this.tracker.removeFromTracker(event.pointerId);
-
     this.updateState(event);
+    this.tracker.removeFromTracker(event.pointerId);
+  }
+
+  protected transformNativeEvent() {
+    const rect = this.view.getBoundingRect();
+    return {
+      x: this.tracker.getLastAvgX() - rect.x,
+      y: this.tracker.getLastAvgY() - rect.y,
+      absoluteX: this.tracker.getLastAvgX(),
+      absoluteY: this.tracker.getLastAvgY(),
+    };
   }
 
   onAdditionalPointerRemove(event: IncomingEvent): void {


### PR DESCRIPTION
# Summary
- 同步dev分支的代码，fix:fixed Gesture.Tap gesture return data property value

## Test Plan

 const doubleTapGesture = Gesture.Tap()
    .enabled(true)
    .numberOfTaps(2)
    .maxDelay(500)
    .onEnd(({ x, y, absoluteX,absoluteY,numberOfPointers }) => {
      console.info('gestureHandle-------------------onEnd  x=' + x + ',y=' + y +";absoluteX:"+absoluteX+";absoluteY:"+absoluteY+', numberOfPointers=' + numberOfPointers);
    });

    <GestureHandlerRootView>
      <GestureDetector
        gesture={Gesture.Race(
          Gesture.Exclusive(doubleTapGesture)
        )}
      >
        <Animated.View style={{
          margin:50,
          height: 200,
          width: 200,
          borderWidth: 3,
          borderColor: 'red',
          backgroundColor: '#fff'
        }}>
          <Text>{'Current tapInfo is:' + text}</Text>
        </Animated.View>
      </GestureDetector>
    </GestureHandlerRootView>

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
