### PR TITLE
fix: children touch event handling

### DIFF
--- a/tester/harmony/gesture_handler/src/main/ets/rnoh/RNGHView.ts
+++ b/tester/harmony/gesture_handler/src/main/ets/rnoh/RNGHView.ts
@@ -20,6 +20,7 @@ export class RNGHView implements View {
   private tag: number
   private buttonRole: boolean
   private boundingBox: BoundingBox
+  private childrenBoundingBoxes: Set<BoundingBox> = new Set()
 
   constructor({ tag, buttonRole, ...boundingBox }: RawTouchableView) {
     this.tag = tag
@@ -35,21 +36,43 @@ export class RNGHView implements View {
     return { ...this.boundingBox }
   }
 
+  getChildrenBoundingRects(): BoundingBox[] {
+    return Array.from(this.childrenBoundingBoxes)
+  }
+
   isPositionInBounds({ x, y }: {
     x: number;
     y: number
   }): boolean {
-    const rect = this.getBoundingRect();
-    return (
+    const rects = [this.boundingBox, ...this.childrenBoundingBoxes]
+    return rects.some(rect => (
       x >= rect.x &&
         x <= rect.x + rect.width &&
         y >= rect.y &&
         y <= rect.y + rect.height
-    );
+    ))
   }
 
   updateBoundingBox(boundingBox: BoundingBox) {
     this.boundingBox = boundingBox
+  }
+
+  attachChildrenBoundingRects(view: RNGHView) {
+    this.childrenBoundingBoxes.add(view.getBoundingRect())
+    for (const childBoundingBox of view.getChildrenBoundingRects()) {
+      this.childrenBoundingBoxes.add(childBoundingBox)
+    }
+  }
+
+  intersectsWith(view: RNGHView): boolean {
+    const rect1 = this.getBoundingRect()
+    const rect2 = view.getBoundingRect()
+    return (
+      rect1.x < rect2.x + rect2.width &&
+      rect1.x + rect1.width > rect2.x &&
+      rect1.y < rect2.y + rect2.height &&
+      rect1.y + rect1.height > rect2.y
+    )
   }
 
   setButtonRole(buttonRole: boolean) {

--- a/tester/harmony/gesture_handler/src/main/ets/rnoh/RNGHViewController.ts
+++ b/tester/harmony/gesture_handler/src/main/ets/rnoh/RNGHViewController.ts
@@ -165,16 +165,9 @@ export class RNGHViewController {
   }
 
   private isInBounds(point: Point): boolean {
-    const x = point.x;
-    const y = point.y;
     const rect = this.view.getBoundingRect();
     this.logger.cloneAndJoinPrefix("isInBounds").debug({ rect })
-    const result =
-      x >= rect.x &&
-        x <= rect.x + rect.width &&
-        y >= rect.y &&
-        y <= rect.y + rect.height;
-    return result;
+    return this.view.isPositionInBounds(point);
   }
 
   private updateActivePointers(touchType: TouchType, pointerId: number): void {

--- a/tester/harmony/gesture_handler/src/main/ets/rnoh/RNGestureHandlerModule.ts
+++ b/tester/harmony/gesture_handler/src/main/ets/rnoh/RNGestureHandlerModule.ts
@@ -1,4 +1,4 @@
-import { UITurboModule, UITurboModuleContext, Tag } from "@rnoh/react-native-openharmony/ts";
+import { TurboModule, TurboModuleContext, Tag } from "@rnoh/react-native-openharmony/ts";
 import { TM } from "@rnoh/react-native-openharmony/generated/ts"
 import {
   GestureHandlerRegistry,
@@ -25,7 +25,7 @@ export enum ActionType {
 }
 
 
-export class RNGestureHandlerModule extends UITurboModule implements TM.RNGestureHandlerModule.Spec {
+export class RNGestureHandlerModule extends TurboModule implements TM.RNGestureHandlerModule.Spec {
   static readonly NAME = "RNGestureHandlerModule"
 
   private gestureHandlerRegistry: GestureHandlerRegistry
@@ -36,7 +36,7 @@ export class RNGestureHandlerModule extends UITurboModule implements TM.RNGestur
   private rootViewControllerByRootTag = new Map<Tag, RNGHRootViewController>()
   private interactionManager: InteractionManager
 
-  constructor(ctx: UITurboModuleContext, isDevModeEnabled: boolean = false) {
+  constructor(ctx: TurboModuleContext, isDevModeEnabled: boolean = false) {
     super(ctx)
     this.cleanLogger =
       isDevModeEnabled && ctx.isDebugModeEnabled ? new DevelopmentRNGHLogger(ctx.logger, "RNGH") :

--- a/tester/src/tests/SharedTest.tsx
+++ b/tester/src/tests/SharedTest.tsx
@@ -10,9 +10,10 @@ import {
   PureNativeButton,
   RectButton,
   LongPressGestureHandler,
+  TapGestureHandler,
 } from 'react-native-gesture-handler';
 import Swipeable from 'react-native-gesture-handler/Swipeable';
-import {StyleSheet, Text, View, Platform} from 'react-native';
+import {StyleSheet, Text, View, Platform, Animated} from 'react-native';
 import {PALETTE} from '../constants';
 import {useState} from 'react';
 
@@ -216,6 +217,36 @@ export function SharedAPITest() {
       <TestCase itShould="emit gesture event when shouldCancelWhenOutside is set to false and pointer is outside LongPressGestureHandler">
         <LongPressGestureHandlerShouldCancelWhenOutsideExample />
       </TestCase>
+      <TestCase
+        itShould="pass when blue square is pressed"
+        initialState={false}
+        arrange={({setState}) => {
+          return (
+            <TapGestureHandler onBegan={() => setState(true)}>
+              <Animated.View
+                key="progress-indicator"
+                style={{
+                    left: 0,
+                    width: 150,
+                    height: 150,
+                    backgroundColor: 'green',
+                }}>
+                <Animated.View
+                  style={{
+                    height: 100,
+                    width: 100,
+                    backgroundColor: 'blue',
+                    marginLeft: 140,
+                  }}
+                />
+              </Animated.View>
+            </TapGestureHandler>
+          );
+        }}
+        assert={({expect, state}) => {
+          expect(state).to.be.true;
+        }}
+      />
     </TestSuite>
   );
 }


### PR DESCRIPTION
## Summary

This MR fixes issue when gesture would not be handled by a child component. When child component intersects with a parent component which has a gesture handler attached, touching the child component should trigger parent gesture handler. In RNHGH case, parent bounding box is extended - Android RNGH has slightly different approach, where they extract parent gesture handler - see [extractAncestorHandlers](https://github.com/software-mansion/react-native-gesture-handler/blob/da9eed867ff09633c506fc9ad08634eaf707cbdb/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt#L446-L468). The issue also exists in RNGH Web, but fixing this in web implementation wouldn't fix the issue in RNHGH.

## Test plan
Tested tester app for regressions.

## Issue links
Closes: #36

See merge request rnoh/react-native-harmony-gesture-handler!84

(cherry picked from commit 250a3074a14b926c6a7eafdd434f9825b0b2520b)
