### PR TITLE
refactor: use createTurboModulesFactory to maintain compatibility

### DIFF
--- a/tester/harmony/gesture_handler/src/main/ets/rnoh/GestureHandlerPackage.ts
+++ b/tester/harmony/gesture_handler/src/main/ets/rnoh/GestureHandlerPackage.ts
@@ -19,7 +19,7 @@ class GestureHandlerTurboModuleFactory extends TurboModulesFactory {
  * @deprecated: Use the package class exported from ../RNOHPackage.ets (2024-10-10)
  */
 export class GestureHandlerPackage extends RNPackage {
-  createUITurboModuleFactory(ctx: TurboModuleContext): TurboModulesFactory {
+  createTurboModulesFactory(ctx: TurboModuleContext): TurboModulesFactory {
     return new GestureHandlerTurboModuleFactory(ctx);
   }
 }


### PR DESCRIPTION
# Summary

- 将新API createUITurboModuleFactory 改为原来的 createTurboModulesFactory。

## Test Plan

![be3e5fdf791390d742dda7d42cffcd6](https://github.com/user-attachments/assets/d0eac6be-78f2-4de7-bedd-896efd04ca5e)


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)
