### PR TITLE
fix: clear activation timeout when there are no pointers present

### DIFF
--- a/tester/harmony/gesture_handler/src/main/ets/gesture-handlers/PanGestureHandler.ts
+++ b/tester/harmony/gesture_handler/src/main/ets/gesture-handlers/PanGestureHandler.ts
@@ -284,7 +284,13 @@ export class PanGestureHandler extends GestureHandler<PanGestureHandlerConfig> {
     if (this.currentState === State.ACTIVE) {
       this.lastPos = this.tracker.getLastAvgPos();
     }
+
     this.tracker.removeFromTracker(event.pointerId);
+    
+    if (this.tracker.getTrackedPointersCount() === 0) {
+      this.clearActivationTimeout();
+    }
+
     if (this.currentState === State.ACTIVE) {
       this.end();
     } else {
@@ -357,5 +363,13 @@ export class PanGestureHandler extends GestureHandler<PanGestureHandlerConfig> {
     } else {
       this.unlockRNGestureResponder?.()
     }
+  }
+
+  protected onCancel(): void {
+    this.clearActivationTimeout();
+  }
+
+  protected onReset(): void {
+    this.clearActivationTimeout();
   }
 }

--- a/tester/harmony/gesture_handler/src/main/ets/rnoh/GestureHandlerPackage.ts
+++ b/tester/harmony/gesture_handler/src/main/ets/rnoh/GestureHandlerPackage.ts
@@ -19,7 +19,7 @@ class GestureHandlerTurboModuleFactory extends TurboModulesFactory {
  * @deprecated: Use the package class exported from ../RNOHPackage.ets (2024-10-10)
  */
 export class GestureHandlerPackage extends RNPackage {
-  createUITurboModuleFactory(ctx: TurboModuleContext): TurboModulesFactory {
+  createTurboModulesFactory(ctx: TurboModuleContext): TurboModulesFactory {
     return new GestureHandlerTurboModuleFactory(ctx);
   }
 }

--- a/tester/index.js
+++ b/tester/index.js
@@ -1,10 +1,5 @@
 import {AppRegistry} from 'react-native';
 import App from './App';
 import {name as appName} from './app.json';
-import LongPressDemo from './demo/shouldCancelWhenOutside';
-import GestureDelayedResponse from './demo/GestureDelayedResponse';
-
 
 AppRegistry.registerComponent(appName, () => App);
-AppRegistry.registerComponent(appName, () => LongPressDemo);
-AppRegistry.registerComponent(appName, () => GestureDelayedResponse);

--- a/tester/src/tests/NewApiTest.tsx
+++ b/tester/src/tests/NewApiTest.tsx
@@ -375,6 +375,35 @@ export function NewApiTest() {
               .false;
           }}
         />
+        <TestCase<Boolean>
+          itShould="change background color to green after LongPress"
+          initialState={false}
+          arrange={({setState, reset}) => {
+            return (
+              <Example
+                onReset={setBackgroundColor => {
+                  setBackgroundColor(PALETTE.DARK_BLUE);
+                  reset();
+                }}
+                createGesture={setBackgroundColor => {
+                  const panGesture = Gesture.Pan()
+                  .enabled(true)
+                  .activateAfterLongPress(1000)
+                  .onStart(() => {
+                    setState(true)
+                    setBackgroundColor(PALETTE.LIGHT_GREEN)
+                  })
+                  return panGesture;
+                }}
+                size={128}
+                label="LONG PRESS FOR 1 SECOND"
+              />
+            );
+          }}
+          assert={({expect, state}) => {
+            expect(state).to.be.true;
+          }}
+        />
       </TestSuite>
       
       <TestSuite name="Gesture callback data">


### PR DESCRIPTION
## Summary
This MR calls `clearActivationTimeout` in `onPointerUp`, `onCancel` and `onReset` methods in `PanGestureHandler`.

Based on [PanGestureHandler.ts](https://github.com/software-mansion/react-native-gesture-handler/blob/79aa1de86086397593700e0b792cd6d6af1e9491/src/web/handlers/PanGestureHandler.ts).

## Test plan
Tested tester app for regressions.

## Issue links
#38 

See merge request rnoh/react-native-harmony-gesture-handler!87

(cherry picked from commit de076cde6b0e61aee754e3b2d577d9076881f1c5)