### PR TITLE
hotfix: properly clear childrenBoundingBoxes array

### DIFF
--- a/tester/harmony/gesture_handler/src/main/ets/rnoh/RNGHRootViewController.ts
+++ b/tester/harmony/gesture_handler/src/main/ets/rnoh/RNGHRootViewController.ts
@@ -94,11 +94,10 @@ export class RNGHRootViewController {
       // with the child bounding box ensures that the parent handlers are called correctly.
       // This approach is slightly different from Android RNGH implementation (extracting parent gesture handlers), 
       // however, the outcome is the same.
-      for (let j = i; j > 1; j--) {
-        const currentView = views[j];
-        const parentView = views[j-1];
-        if (parentView.intersectsWith(currentView)) {
-          parentView.attachChildrenBoundingRects(currentView);
+      for (let j = i - 1; j > 0; j--) {
+        const parentView = views[j];
+        if (parentView.intersectsWith(view)) {
+          parentView.attachChildrenBoundingRects(view);
         }
       }
     }
@@ -118,6 +117,7 @@ export class RNGHRootViewController {
 
     if (touchEvent.type === TouchType.Up || touchEvent.type === TouchType.Cancel) {
       touchableViews.forEach(view => this.touchableViewsMultiset.remove(view));
+      views.forEach(view => view.resetChildrenBoundingRects());
     }
   }
 

--- a/tester/harmony/gesture_handler/src/main/ets/rnoh/RNGHView.ts
+++ b/tester/harmony/gesture_handler/src/main/ets/rnoh/RNGHView.ts
@@ -57,6 +57,10 @@ export class RNGHView implements View {
     this.boundingBox = boundingBox
   }
 
+  resetChildrenBoundingRects() {
+    this.childrenBoundingBoxes.clear()
+  }
+
   attachChildrenBoundingRects(view: RNGHView) {
     this.childrenBoundingBoxes.add(view.getBoundingRect())
     for (const childBoundingBox of view.getChildrenBoundingRects()) {


### PR DESCRIPTION
This MR removes memory leak caused by not clearing `childrenBoundingBoxes` array in RNGHView.ts

Related: #43 .

See merge request rnoh/react-native-harmony-gesture-handler!89

(cherry picked from commit cae608c2458a6cce85085553f713208ed809f437)
