### PR TITLE
fix: ensure correct pointer count at gesture end

### DIFF
--- a/tester/harmony/gesture_handler/src/main/ets/rnoh/RNGHViewController.ts
+++ b/tester/harmony/gesture_handler/src/main/ets/rnoh/RNGHViewController.ts
@@ -20,6 +20,9 @@ export class RNGHViewController {
   private view: View;
   private logger: RNGHLogger;
 
+  private maxActivePointers = -1;
+  private lastPointerEventTimestamp = -1;
+
   constructor(view: View, logger: RNGHLogger) {
     this.logger = logger.cloneAndJoinPrefix(`RNGHViewTouchHandler`)
     this.view = view;
@@ -128,6 +131,25 @@ export class RNGHViewController {
       yAbsolute,
     );
     this.updateActivePointers(changedTouch.type, changedTouch.id);
+
+    /**
+     * FIXME: Hack to fix pointerCount to be consistent with iOS.
+     * When we get the UP event, we store the largest number of
+     * pointers. When the time difference between the last UP event and the current
+     * event is greater than the number of pointers * 20ms, we assume that
+     * the number of pointers has changed and we set it to the current number of pointers.
+     */ 
+    if (e.type === TouchType.Up && this.maxActivePointers < e.touches.length) {
+      this.maxActivePointers = e.touches.length;
+      this.lastPointerEventTimestamp = e.timestamp;
+    }
+    let pointerCount = this.maxActivePointers;
+    if (pointerCount === -1 || e.timestamp - this.lastPointerEventTimestamp > this.maxActivePointers * 20) {
+      this.maxActivePointers = -1;
+      this.lastPointerEventTimestamp = -1;
+      pointerCount = e.touches.length;
+    }
+
     return {
       x: xAbsolute,
       y: yAbsolute,
@@ -139,7 +161,7 @@ export class RNGHViewController {
       buttons: 0,
       time: e.timestamp,
       allTouches: e.touches.map(touch => this.mapTouchObjectToTouch(touch)),
-      pointerCount: e.touches.length,
+      pointerCount,
       changedTouches: e.changedTouches.map(touch =>
       this.mapTouchObjectToTouch(touch),
       ),


### PR DESCRIPTION
## Description
This pull request addresses an issue where touch event handling on Android and HarmonyOS makes it difficult to accurately detect and emit the correct number of lifted pointers at the end of a gesture, in order to ensure consistent behavior with iOS. The core problem lies in the native touch event models on these platforms, which differ from that of iOS and prevent reliable tracking of simultaneously lifted pointers during gesture termination. This discrepancy affects the ability to consistently report the correct number of active pointers throughout a gesture — particularly at its conclusion (e.g., during the onEnd callback of a pan gesture).

## Test plan
1. Test the repro available in the issue (or discord message)
2. Test repro below:

```tsx
import React, { useState } from 'react';
import { View, Text, StyleSheet } from 'react-native';
import { GestureDetector, Gesture, GestureHandlerRootView } from 'react-native-gesture-handler';

const PanGestureExample = () => {
  const [pointerCount, setPointerCount] = useState(0);
  const [status, setStatus] = useState('Waiting for touch...');
  const [gestureInfo, setGestureInfo] = useState('');

  const panGesture = Gesture.Pan()
    .onBegin((event) => {
      setStatus('Gesture Began');
      setPointerCount(event.numberOfPointers);
      setGestureInfo(`x: ${event.x}, y: ${event.y}`);
    })
    .onStart((event) => {
      setStatus('Gesture Started');
      setPointerCount(event.numberOfPointers);
      setGestureInfo(`Translation X: ${event.translationX}, Y: ${event.translationY}`);
    })
    .onUpdate((event) => {
      setStatus('Gesture Updating');
      setPointerCount(event.numberOfPointers);
      setGestureInfo(`Translation X: ${event.translationX}, Y: ${event.translationY}`);
    })
    .onEnd((event) => {
      setStatus('Gesture Ended');
      setPointerCount(event.numberOfPointers);
      setGestureInfo(`Final velocity X: ${event.velocityX}, Y: ${event.velocityY}`);
    })
    .onFinalize(() => {
      setStatus('Gesture Finalized');
      setGestureInfo('');
    })
    .onTouchesCancelled(() => {
      setStatus('Touches Cancelled');
    });

  return (
    <GestureHandlerRootView style={{ flex: 1 }}>
    <GestureDetector gesture={panGesture}>
      <View style={styles.container}>
        <Text style={styles.title}>Pan Gesture Example</Text>
        <Text style={styles.text}>Status: {status}</Text>
        <Text style={styles.text}>Number of Pointers: {pointerCount}</Text>
        <Text style={styles.text}>Gesture Info: {gestureInfo}</Text>
        <Text style={styles.instruction}>Drag anywhere to test the gesture!</Text>
      </View>
    </GestureDetector>
    </GestureHandlerRootView>
  );
};

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#e8f5e9',
  },
  title: {
    fontSize: 22,
    fontWeight: 'bold',
    marginBottom: 15,
  },
  text: {
    fontSize: 16,
    marginBottom: 8,
  },
  instruction: {
    marginTop: 20,
    fontSize: 14,
    fontStyle: 'italic',
    color: 'gray',
  },
});

export default PanGestureExample;
```

