### PR TITLE
fix: inverted scroll list tap gesture detection

### DIFF
--- a/tester/harmony/gesture_handler/src/main/cpp/componentInstances/RNGestureHandlerButtonComponentInstance.cpp
+++ b/tester/harmony/gesture_handler/src/main/cpp/componentInstances/RNGestureHandlerButtonComponentInstance.cpp
@@ -4,7 +4,7 @@
 
 namespace rnoh {
 RNGestureHandlerButtonComponentInstance::RNGestureHandlerButtonComponentInstance(Context context)
-    : CppComponentInstance(std::move(context)){};
+    : CppComponentInstance(std::move(context)) {};
 
 StackNode &RNGestureHandlerButtonComponentInstance::getLocalRootArkUINode() { return m_stackNode; };
 

--- a/tester/harmony/gesture_handler/src/main/cpp/componentInstances/RNGestureHandlerButtonComponentInstance.h
+++ b/tester/harmony/gesture_handler/src/main/cpp/componentInstances/RNGestureHandlerButtonComponentInstance.h
@@ -1,7 +1,7 @@
 #pragma once
-#import "RNOH/CppComponentInstance.h"
-#import "RNOH/arkui/StackNode.h"
-#import "generated/RNGestureHandlerButtonComponentDescriptor.h"
+#include "RNOH/CppComponentInstance.h"
+#include "RNOH/arkui/StackNode.h"
+#include "generated/RNGestureHandlerButtonComponentDescriptor.h"
 
 namespace rnoh {
 class RNGestureHandlerButtonComponentInstance

--- a/tester/harmony/gesture_handler/src/main/cpp/componentInstances/RNGestureHandlerRootViewComponentInstance.cpp
+++ b/tester/harmony/gesture_handler/src/main/cpp/componentInstances/RNGestureHandlerRootViewComponentInstance.cpp
@@ -126,44 +126,98 @@ void RNGestureHandlerRootViewComponentInstance::onChildRemoved(
     m_stackNode.removeChild(childComponentInstance->getLocalRootArkUINode());
 }
 
+std::deque<TouchTarget::Shared>
+RNGestureHandlerRootViewComponentInstance::buildHierarchy(TouchTarget::Shared const &touchTarget) const {
+    std::deque<TouchTarget::Shared> touchTargets{};
+    auto current = touchTarget;
+    while (current != nullptr) {
+        touchTargets.push_front(current);
+        current = current->getTouchTargetParent();
+    }
+    return touchTargets;
+}
+
+facebook::react::Transform RNGestureHandlerRootViewComponentInstance::getInitialTransform() {
+    if (auto surface = this->getSurface().lock()) {
+        const auto &viewportOffset = surface->getLayoutContext().viewportOffset;
+        return facebook::react::Transform::Translate(viewportOffset.x, viewportOffset.y, 0);
+    }
+
+    LOG(WARNING) << "RNGH::Surface unavailable, using identity transform";
+    return facebook::react::Transform::Identity();
+}
+
+RNGestureHandlerRootViewComponentInstance::TouchableView
+RNGestureHandlerRootViewComponentInstance::createTouchableView(const TouchTarget::Shared &node,
+                                                               const facebook::react::Rect &screenBounds) const {
+    const bool buttonRole = dynamic_cast<RNGestureHandlerButtonComponentInstance *>(node.get()) != nullptr;
+
+    return RNGestureHandlerRootViewComponentInstance::TouchableView{
+        .tag = node->getTouchTargetTag(),
+        .width = screenBounds.size.width,
+        .height = screenBounds.size.height,
+        .x = screenBounds.origin.x,
+        .y = screenBounds.origin.y,
+        .buttonRole = buttonRole,
+    };
+}
+
+facebook::react::Transform
+RNGestureHandlerRootViewComponentInstance::buildNodeTransform(const TouchTarget::Shared &node)  const {
+    const auto frame = node->getLayoutMetrics().frame;
+    auto currentOffset = node->getCurrentOffset();
+    const auto nodeTransform = node->getTransform();
+
+    // For inverted lists, the scroll offset needs to be applied in the opposite direction
+    if (facebook::react::Transform::isVerticalInversion(nodeTransform)) {
+        currentOffset.y = -currentOffset.y;
+    }
+
+    if (facebook::react::Transform::isHorizontalInversion(nodeTransform)) {
+        currentOffset.x = -currentOffset.x;
+    }
+
+    const auto frameCenter = facebook::react::Point{frame.size.width * 0.5f, frame.size.height * 0.5f};
+
+    // First, position the view at its layout origin (frame.origin - currentOffset).
+    // Then apply its local transform around the view's center:
+    // translate to center -> nodeTransform -> translate back.
+    return facebook::react::Transform::Translate(frame.origin.x - currentOffset.x, frame.origin.y - currentOffset.y,
+                                                 0) *
+           facebook::react::Transform::Translate(frameCenter.x, frameCenter.y, 0) * nodeTransform *
+           facebook::react::Transform::Translate(-frameCenter.x, -frameCenter.y, 0);
+}
+
 std::vector<RNGestureHandlerRootViewComponentInstance::TouchableView>
 RNGestureHandlerRootViewComponentInstance::findTouchableViews(float componentX, float componentY) {
     auto touchTarget = findTargetForTouchPoint({.x = componentX, .y = componentY}, this->shared_from_this());
-    std::vector<TouchTarget::Shared> touchTargets{};
-    auto tmp = touchTarget;
-    while (tmp != nullptr) {
-        touchTargets.push_back(tmp);
-        tmp = tmp->getTouchTargetParent();
+    if (touchTarget == nullptr) {
+        return {};
     }
-    std::reverse(touchTargets.begin(), touchTargets.end());
+    // Build hierarchy from root to touchTarget
+    auto touchTargets = buildHierarchy(touchTarget);
 
     std::vector<TouchableView> touchableViews{};
-    float offsetX = 0;
-    float offsetY = 0;
-    auto surface = this->getSurface().lock();
-    if (surface != nullptr) {
-        offsetX = surface->getLayoutContext().viewportOffset.x;
-        offsetY = surface->getLayoutContext().viewportOffset.y;
-    } else {
-        LOG(WARNING) << "Surface is nullptr";
-    }
-    for (auto &touchTarget : touchTargets) {
-        auto buttonRole = dynamic_cast<RNGestureHandlerButtonComponentInstance *>(touchTarget.get()) != nullptr;
-        auto frame = touchTarget->getLayoutMetrics().frame;
-        auto transform = touchTarget->getTransform();
-        auto transformedFrame = frame * transform;
-        touchableViews.push_back({
-            .tag = touchTarget->getTouchTargetTag(),
-            .width = transformedFrame.size.width,
-            .height = transformedFrame.size.height,
-            .x = transformedFrame.origin.x + offsetX,
-            .y = transformedFrame.origin.y + offsetY,
-            .buttonRole = buttonRole,
-        });
-        offsetX += transformedFrame.origin.x;
-        offsetY += transformedFrame.origin.y;
-        offsetX -= touchTarget->getCurrentOffset().x;
-        offsetY -= touchTarget->getCurrentOffset().y;
+    touchableViews.reserve(touchTargets.size());
+
+    auto cumulativeTransform = getInitialTransform();
+
+    // It calculates the cumulative transform for each view in the hierarchy to map its
+    // bounding box to screen coordinates
+    for (const auto &node : touchTargets) {
+        const auto frame = node->getLayoutMetrics().frame;
+
+        cumulativeTransform = cumulativeTransform * buildNodeTransform(node);
+
+        // Map this node's local corners to screen space
+        const auto a = facebook::react::Point{0.0f, 0.0f} * cumulativeTransform;
+        const auto b = facebook::react::Point{frame.size.width, 0.0f} * cumulativeTransform;
+        const auto c = facebook::react::Point{frame.size.width, frame.size.height} * cumulativeTransform;
+        const auto d = facebook::react::Point{0.0f, frame.size.height} * cumulativeTransform;
+
+        const auto boundingRect = facebook::react::Rect::boundingRect(a, b, c, d);
+
+        touchableViews.push_back(createTouchableView(node, boundingRect));
     }
 
     return touchableViews;

--- a/tester/harmony/gesture_handler/src/main/cpp/componentInstances/RNGestureHandlerRootViewComponentInstance.h
+++ b/tester/harmony/gesture_handler/src/main/cpp/componentInstances/RNGestureHandlerRootViewComponentInstance.h
@@ -1,11 +1,12 @@
 #pragma once
-#import "RNOH/CppComponentInstance.h"
-#import "RNOH/arkui/StackNode.h"
-#import "RNOH/arkui/NativeNodeApi.h"
-#import "RNOH/arkui/UIInputEventHandler.h"
-#import "RNOH/RNInstanceCAPI.h"
-#import "generated/RNGestureHandlerRootViewComponentDescriptor.h"
-#import "RNGestureHandlerButtonComponentInstance.h"
+#include "RNGestureHandlerButtonComponentInstance.h"
+#include "RNOH/CppComponentInstance.h"
+#include "RNOH/RNInstanceCAPI.h"
+#include "RNOH/arkui/NativeNodeApi.h"
+#include "RNOH/arkui/StackNode.h"
+#include "RNOH/arkui/UIInputEventHandler.h"
+#include "generated/RNGestureHandlerRootViewComponentDescriptor.h"
+#include <deque>
 
 namespace rnoh {
 class RNGestureHandlerRootViewComponentInstance
@@ -59,6 +60,11 @@ private:
     std::unique_ptr<UIInputEventHandler> m_touchHandler;
 
     std::vector<TouchableView> findTouchableViews(float componentX, float componentY);
+    std::deque<TouchTarget::Shared> buildHierarchy(TouchTarget::Shared const &touchTarget) const;
+    facebook::react::Transform getInitialTransform();
+    facebook::react::Transform buildNodeTransform(const TouchTarget::Shared &node) const;
+    TouchableView createTouchableView(const TouchTarget::Shared &node, const facebook::react::Rect &screenBounds) const;
+
     folly::dynamic dynamicFromTouchableViews(const std::vector<TouchableView> &touchableViews);
     folly::dynamic convertNodeTouchPointToDynamic(ArkUI_UIInputEvent *e, int32_t index = 0);
     Surface::Weak getSurface();

--- a/tester/src/tests/NewApiTest.tsx
+++ b/tester/src/tests/NewApiTest.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Animated,
   Pressable,
+  FlatList,
 } from 'react-native';
 import {
   Gesture,
@@ -22,6 +23,7 @@ import {
   FlingGestureHandlerEventPayload,
   PinchGestureHandlerEventPayload,
   LongPressGestureHandlerEventPayload,
+  LongPressGesture,
 } from 'react-native-gesture-handler';
 import {PALETTE} from '../constants';
 
@@ -720,6 +722,23 @@ export function NewApiTest() {
           />
         </ScrollView>
       </TestCase>
+
+      <TestCase
+        itShould="tap gestures work when FlatList is inverted"
+        initialState={false}
+        arrange={({setState}) => {
+          return (
+            <FlatListExample
+              longPressGesture={Gesture.LongPress().onStart(e => {
+                console.log('onPress event logLongPressGesture: ', e);
+                setState(true);
+              })}
+            />
+          );
+        }}
+        assert={({expect, state}) => {
+          expect(state).to.be.true;
+        }}></TestCase>
     </TestSuite>
   );
 }
@@ -845,6 +864,46 @@ const OverLapExample: React.FC = () => {
         </View>
       </GestureDetector>
       <Text style={{color: 'white'}}>Tap area: {tapRange}</Text>
+    </View>
+  );
+};
+
+const FlatListExample = ({
+  longPressGesture,
+}: {
+  longPressGesture: LongPressGesture;
+}) => {
+  const logTap = Gesture.Tap().onStart(e => {
+    console.log('onPress event logTag: ', e);
+  });
+
+  const FlatListItem = ({firstItem}: {firstItem: boolean}) => {
+    return (
+      <GestureDetector gesture={Gesture.Simultaneous(logTap, longPressGesture)}>
+        <View>
+          <Text
+            style={{
+              width: 100,
+              height: 50,
+              backgroundColor: 'skyblue',
+              marginBottom: 20,
+            }}>
+            {firstItem ? 'SCROLL TO THE TOP AND LONG PRESS' : 'PRESS ME'}
+          </Text>
+        </View>
+      </GestureDetector>
+    );
+  };
+
+  return (
+    <View style={{height: 200}}>
+      <FlatList
+        inverted={true}
+        data={Array.from({length: 10}, (_, i) => ({key: `${i + 1}`}))}
+        renderItem={({item, index}) => (
+          <FlatListItem key={item.key} firstItem={index === 0} />
+        )}
+      />
     </View>
   );
 };


### PR DESCRIPTION
When `transform: [{scaleY: -1}]` is applied to a ScrollView, tap gestures fail to detect items due to incorrect transform composition and offset handling in hit-box calculations.

This fix:
- Composes transforms root→leaf with center-pivot per node
- Applies viewport and scroll offsets in the correct transform space
- Transforms corner points and bounds them for screen-space hit rectangles

Repro:
```
import React from 'react';
import { View, Text, ScrollView } from 'react-native';
import { GestureHandlerRootView, GestureDetector, Gesture } from 'react-native-gesture-handler';

function GestureDetectorItem(props) {
  const logTap = Gesture.Tap().onStart(() => {
    console.log('onPress event logTap');
  });

  const logLongPressGesture = Gesture.LongPress().onStart(e => {
    console.log('onPress event logLongPressGesture', e);
  });
  const composed = Gesture.Simultaneous(logTap, logLongPressGesture);

  return (
    <GestureDetector gesture={composed}>
      <View
        style={{
          width: 100,
          height: 50,
          backgroundColor: 'skyblue',
          borderWidth: 1,
        }}/>
    </GestureDetector>
  );
}

export default function App() {
  return (
    <GestureHandlerRootView style={{ flex: 1, margin: 50 }}>
      <View
        style={{
          flex: 1,
          transform: [{ scaleY: -1 }],
          gap: 20,
          borderWidth: 1,
        }}>
          <GestureDetectorItem />
      </View>
    </GestureHandlerRootView>
  );
}
```

# Summary
- This PR solves the issue #60 
- The fix:
a) Composes transforms root→leaf with center-pivot per node. Previously, parent transformations were not applied.
b) Applies viewport and scroll offsets in the correct transform space. Previously, the offset was incorrectly applied when there was a horizontal or vertical inversion.
c) Transforms corner points and bounds them for screen-space hit rectangles.
- The fix is applied to `RNGestureHandlerRootViewComponentInstance::findTouchableViews`

## Test Plan
1. Open the tester app.
2. Scroll to FlatListExample.
3. Verify that long press for the inverted item is detected.

<img width="315" height="680" alt="Screenshot_20251008094148690" src="https://github.com/user-attachments/assets/1f77114c-bbae-4832-ad34-3870f50a403c" />


## Checklist

- [x] I have tested this on a device and a simulator
- [x] I have already compared the effects/features with the Android or iOS platforms
- [x] I added a test for the API (if applicable)
- [ ] I have updated the JS/TS (if applicable)
- [ ] I updated the documentation (if applicable)
